### PR TITLE
Adapt the code to avoid to throw an exception if Argocd is not enabled

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/argocd/deployment/devservices/ArgocdExtensionProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/argocd/deployment/devservices/ArgocdExtensionProcessor.java
@@ -70,8 +70,8 @@ public class ArgocdExtensionProcessor {
 
         if (!argoConfig.enabled() && !kubeServiceInfo.isPresent()) {
             // Argocd Dev Service not enabled and Kubernetes test container has not been created ...
-            throw new RuntimeException(
-                    "Dev services is not enabled for Argo CD and Kubernetes test container has not been created ...");
+            LOG.warn("Dev services is not enabled for Argo CD and Kubernetes test container has not been created ...");
+            return;
         }
 
         // Convert the kube config yaml to its Java Class
@@ -238,6 +238,8 @@ public class ArgocdExtensionProcessor {
                 kubeServiceInfo.get().getContainerId(),
                 new ContainerShutdownCloseable(new DummyContainer(), ArgoCDProcessor.FEATURE),
                 configOverrides).toBuildItem());
+
+        LOG.info("Created the argocd platform on kind ...");
     }
 
     private class DummyContainer extends GenericContainer<DummyContainer> implements Closeable {

--- a/deployment/src/main/java/io/quarkiverse/argocd/deployment/devui/ArgocdDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/argocd/deployment/devui/ArgocdDevUIProcessor.java
@@ -19,30 +19,31 @@ public class ArgocdDevUIProcessor {
     @BuildStep(onlyIf = IsDevelopment.class)
     void createCard(Optional<ArgocdDevServiceInfoBuildItem> info, BuildProducer<CardPageBuildItem> cardPage) {
 
-        CardPageBuildItem card = new CardPageBuildItem();
-        LOG.debug("Creating card page");
-
         info.ifPresent(i -> {
+            CardPageBuildItem card = new CardPageBuildItem();
+            LOG.debug("Creating card page");
+
             String url = String.format("https://%s:%s", i.host(), i.hostPort());
             LOG.debug("Creating an external link page for: argocd UI");
             card.addPage(Page.externalPageBuilder("Argocd Dashboard")
                     .doNotEmbed()
                     .icon("font-awesome-solid:code-branch")
                     .url(url));
+
+            LOG.debug("Creating an external link page for: argocd project & version");
+            final ExternalPageBuilder versionPage = Page.externalPageBuilder("Argocd project")
+                    .icon("font-awesome-solid:tag")
+                    .url("https://argo-cd.readthedocs.io/en/stable/")
+                    .doNotEmbed()
+                    .staticLabel("2.13.2");
+
+            LOG.debug("Add version page");
+            card.addPage(versionPage);
+            LOG.debug("Set custom car with js");
+            card.setCustomCard("qwc-argocd-card.js");
+            LOG.debug("Produce ...");
+            cardPage.produce(card);
+
         });
-
-        LOG.debug("Creating an external link page for: argocd project & version");
-        final ExternalPageBuilder versionPage = Page.externalPageBuilder("Argocd project")
-                .icon("font-awesome-solid:tag")
-                .url("https://argo-cd.readthedocs.io/en/stable/")
-                .doNotEmbed()
-                .staticLabel("2.13.2");
-
-        LOG.debug("Add version page");
-        card.addPage(versionPage);
-        LOG.debug("Set custom car with js");
-        card.setCustomCard("qwc-argocd-card.js");
-        LOG.debug("Produce ...");
-        cardPage.produce(card);
     }
 }


### PR DESCRIPTION
- Adapt the code to avoid to throw an exception if Argocd is not enabled and show a warning message. 
- Check also the presence of `ArgocdDevServiceInfoBuildItem` to enbale the Argocd card
- #80