### PR TITLE
Bump quarkus version to 3.20.1 fixing class not found for jgit

### DIFF
--- a/.github/workflows/cli-integration-test.yml
+++ b/.github/workflows/cli-integration-test.yml
@@ -70,11 +70,11 @@ jobs:
           shopt -s expand_aliases
           alias quarkus="java -jar ${GITHUB_WORKSPACE}/quarkus-cli.jar"
           
-          echo "## Create a Quarkus project"
+          echo "## Create a Quarkus project using the version: $QUARKUS_CLI_VERSION"
 
           TMP_DIR=$(mktemp -d)
           pushd $TMP_DIR
-          quarkus create app
+          quarkus create app -P $QUARKUS_CLI_VERSION
           cd code-with-quarkus
           
           echo "## Init a git repository and push the code"

--- a/.github/workflows/cli-integration-test.yml
+++ b/.github/workflows/cli-integration-test.yml
@@ -32,7 +32,7 @@ defaults:
     shell: bash
 
 env:
-  QUARKUS_CLI_VERSION: 3.14.4
+  QUARKUS_CLI_VERSION: 3.20.1
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,13 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.19.2</quarkus.version>
+        <quarkus.version>3.20.1</quarkus.version>
         <!-- <quarkus.version>999-SNAPSHOT</quarkus.version> -->
         <sundrio.version>0.103.1</sundrio.version>
         <lombok.version>1.18.44</lombok.version>
         <kubernetes-client.version>7.6.1</kubernetes-client.version>
-        <quarkus-jgit.version>3.3.3</quarkus-jgit.version>
+        <!-- Moving quarkus jgit from 3.3.3 to 3.6.2 requires also to bump the quarkus version to 3.20.1 at least: https://github.com/quarkusio/quarkus/pull/47137 -->
+        <quarkus-jgit.version>3.6.2</quarkus-jgit.version>
         <quarkus-helm.version>1.3.0</quarkus-helm.version>
         <surefire-plugin.version>3.5.5</surefire-plugin.version>
         <!-- Formatting Plugins -->


### PR DESCRIPTION
- Moving quarkus jgit from 3.3.3 to 3.6.2 requires also to bump the quarkus version to 3.20.1 at least: https://github.com/quarkusio/quarkus/pull/47137
- #106 